### PR TITLE
Add read-only calendar view for white-label

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -555,6 +555,10 @@ declare module 'upload-post' {
       logoImage?: string;
       redirectButtonText?: string;
       platforms?: string[];
+      showCalendar?: boolean;
+      readonlyCalendar?: boolean;
+      connectTitle?: string;
+      connectDescription?: string;
     }): Promise<JwtResponse>;
 
     /**

--- a/index.js
+++ b/index.js
@@ -685,6 +685,10 @@ export class UploadPost {
    * @param {string} [options.logoImage] - Logo image URL for the linking page
    * @param {string} [options.redirectButtonText] - Text for redirect button
    * @param {string[]} [options.platforms] - Platforms to show for connection
+   * @param {boolean} [options.showCalendar] - Whether to show the calendar view
+   * @param {boolean} [options.readonlyCalendar] - Show only a read-only calendar (no editing, no account connection)
+   * @param {string} [options.connectTitle] - Custom title for the connection page
+   * @param {string} [options.connectDescription] - Custom description for the connection page
    * @returns {Promise<Object>} JWT and connection URL
    */
   async generateJwt(username, options = {}) {
@@ -693,6 +697,10 @@ export class UploadPost {
     if (options.logoImage) body.logo_image = options.logoImage;
     if (options.redirectButtonText) body.redirect_button_text = options.redirectButtonText;
     if (options.platforms && options.platforms.length > 0) body.platforms = options.platforms;
+    if (options.showCalendar !== undefined) body.show_calendar = options.showCalendar;
+    if (options.readonlyCalendar !== undefined) body.readonly_calendar = options.readonlyCalendar;
+    if (options.connectTitle) body.connect_title = options.connectTitle;
+    if (options.connectDescription) body.connect_description = options.connectDescription;
     return this._request('/uploadposts/users/generate-jwt', 'POST', body);
   }
 


### PR DESCRIPTION
# PR Description: Read-Only Calendar Support for White-Label Clients

## Overview
Add read-only calendar view capability to enable white-label calendar widgets for client-facing implementations. This feature allows profiles to display calendar events without permitting direct editing or creation of posts.

## Changes

### Backend (API)
- **Profile Configuration**: Added `readonly_calendar` parameter to the JWT generation and validation endpoints
- **Data Persistence**: Implemented storage and retrieval of `readonly_calendar` preference per profile with default value of `False`
- **Profile Updates**: Extended profile modification logic to handle `readonly_calendar` flag changes with appropriate logging

### Frontend (Calendar Component)
- **Read-Only Prop**: Introduced `readOnly` parameter to Calendar component to control edit permissions
- **Disabled Operations**:
  - Event drag-and-drop functionality
  - Date/time selection and clicking
  - Post creation via "New Post" button
  - Event editing modal access
  - Composer modal display
  - Post action buttons in preview modal
- **Calendar Configuration**: Updated FullCalendar settings (`editable`, `selectable`, `selectMirror`) to respect read-only state

### Admin Interface
- **User Management**: Added UI controls in `UserManagement.jsx` and `ConnectProfile.jsx` to toggle read-only calendar mode per profile
- **Configuration**: Enables administrators to easily enable/disable edit capabilities for specific client implementations

## Use Cases
- White-label calendar widgets for external clients viewing scheduled posts
- Read-only calendar previews for stakeholder visibility
- Calendar sharing without modification rights

## Backward Compatibility
✅ Defaults to `readOnly: false` - existing implementations unaffected