### PR TITLE
Make TikTok title optional, document 90-char limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ These options work across all upload methods:
 
 | Option | Description |
 |--------|-------------|
-| `title` | Post title/caption (required) |
+| `title` | Post title/caption (required for most platforms; optional for TikTok-only uploads) |
 | `user` | Profile name (required) |
 | `platforms` | Target platforms array (required) |
 | `firstComment` | First comment to post |

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,8 +43,8 @@ declare module 'upload-post' {
   // ==================== Common Options ====================
 
   export interface CommonUploadOptions {
-    /** Post title/caption */
-    title: string;
+    /** Post title/caption. Required for most platforms; optional when uploading only to TikTok. */
+    title?: string;
     /** User identifier (profile name) */
     user: string;
     /** First comment to post after publishing */

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ export class UploadPost {
    */
   _addCommonParams(form, options) {
     form.append('user', options.user);
-    form.append('title', options.title);
+    if (options.title) form.append('title', options.title);
 
     // Platforms
     const platforms = Array.isArray(options.platforms) ? options.platforms : [options.platforms];
@@ -271,7 +271,7 @@ export class UploadPost {
    * 
    * @param {string} videoPathOrUrl - Path to video file or video URL
    * @param {Object} options - Upload options
-   * @param {string} options.title - Video title/caption
+   * @param {string} [options.title] - Video title/caption. Required for most platforms; optional for TikTok-only uploads.
    * @param {string} options.user - User identifier (profile name)
    * @param {string[]} options.platforms - Target platforms (tiktok, instagram, youtube, linkedin, facebook, pinterest, threads, bluesky, x)
    * @param {string} [options.description] - Video description
@@ -383,7 +383,7 @@ export class UploadPost {
    * 
    * @param {string[]} photosPathsOrUrls - Array of photo file paths or URLs
    * @param {Object} options - Upload options
-   * @param {string} options.title - Post title/caption
+   * @param {string} [options.title] - Post title/caption. Required for most platforms; optional for TikTok-only uploads.
    * @param {string} options.user - User identifier (profile name)
    * @param {string[]} options.platforms - Target platforms (tiktok, instagram, linkedin, facebook, x, threads, pinterest, reddit, bluesky)
    * @param {string} [options.description] - Photo description


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Makes `title` optional for TikTok-only uploads in the npm client library, aligning with the backend change where TikTok no longer requires a title for video or photo posts.

## Changes

- **`index.d.ts`**: Changed `title` from required (`title: string`) to optional (`title?: string`) in `CommonUploadOptions` interface, with updated JSDoc noting it's required for most platforms but optional for TikTok-only uploads
- **`index.js`**: 
  - `_addCommonParams()` now conditionally appends `title` to the form data only when provided, instead of always sending it
  - Updated JSDoc for `uploadVideo()` and `uploadPhotos()` to mark `title` as optional with clarifying note
- **`README.md`**: Updated the common options table to indicate `title` is optional for TikTok-only uploads

## Notes

- No breaking changes: existing code that always passes `title` continues to work identically
- The server validates and returns an error if `title` is omitted for platforms that require it, so client-side enforcement is intentionally relaxed to match