### PR TITLE
Make TikTok titles optional, document 90 char limit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,8 +43,8 @@ declare module 'upload-post' {
   // ==================== Common Options ====================
 
   export interface CommonUploadOptions {
-    /** Post title/caption */
-    title: string;
+    /** Post title/caption. Required for YouTube, Reddit, and text posts. Optional for TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, Pinterest. */
+    title?: string;
     /** User identifier (profile name) */
     user: string;
     /** First comment to post after publishing */

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ export class UploadPost {
    */
   _addCommonParams(form, options) {
     form.append('user', options.user);
-    form.append('title', options.title);
+    if (options.title) form.append('title', options.title);
 
     // Platforms
     const platforms = Array.isArray(options.platforms) ? options.platforms : [options.platforms];


### PR DESCRIPTION
Based on my analysis of the modified files and the overall diff context, here's the PR description:

---

## Summary

Make the `title` field optional in the npm SDK to align with backend changes where titles are only required for YouTube, Reddit, and text posts. TikTok and other platforms no longer require a title for video/photo uploads.

## Changes

- **`index.d.ts`**: Changed `title` from required (`title: string`) to optional (`title?: string`) in `CommonUploadOptions`, with updated JSDoc documenting which platforms require it (YouTube, Reddit, text posts) vs. which treat it as optional (TikTok, Instagram, Facebook, LinkedIn, X, Threads, Bluesky, Pinterest)
- **`index.js`**: Title is conditionally appended to the form data (`if (options.title)`) rather than always sent, allowing uploads without a title for platforms that don't require one

## Context

This is the npm SDK counterpart to backend and frontend changes that:
- Relax title validation on the API server to only enforce titles for YouTube and Reddit (videos) or Reddit-only (photos)
- Add a 90-character limit for TikTok titles in the frontend UI with a character counter
- Update frontend validation to only block submission for missing titles when YouTube/Reddit are selected