### PR TITLE
Fix link preview for LinkedIn/Bluesky uploads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -343,12 +343,22 @@ declare module 'upload-post' {
     platforms: PhotoPlatform[];
   }
 
+  export interface LinkPreviewOptions {
+    /** Generic URL for link preview card (works for LinkedIn, Bluesky, Facebook). Platform-specific params take priority. */
+    linkUrl?: string;
+    /** URL for link preview card on LinkedIn */
+    linkedinLinkUrl?: string;
+    /** URL for external embed link preview on Bluesky */
+    blueskyLinkUrl?: string;
+  }
+
   export interface UploadTextOptions extends CommonUploadOptions,
     LinkedInOptions,
     FacebookTextOptions,
     XTextOptions,
     ThreadsOptions,
-    RedditOptions {
+    RedditOptions,
+    LinkPreviewOptions {
     /** Target platforms */
     platforms: TextPlatform[];
   }


### PR DESCRIPTION
Here's the PR description:

---

## Fix link preview cards for LinkedIn and Bluesky in `upload_text`

### Problem

When using `uploadText` to post to LinkedIn and Bluesky, link preview cards (OpenGraph embeds) were not rendered. Text posts containing URLs would appear as plain text without the rich preview card that users expect.

### Changes

**Backend (sass-ai)**
- **`social_utils.py`** — Added `fetch_og_metadata()` to scrape OpenGraph meta tags (title, description, image) from a given URL, and `fetch_image_as_bytes()` to download thumbnail images for embed cards
- **`bluesky.py`** — Added `_build_bluesky_external_embed()` which fetches OG metadata and uploads the thumbnail as a blob to build a native Bluesky `AppBskyEmbedExternal` card. Updated `upload_text_bluesky()` to accept a `link_url` parameter and attach the external embed to the first post in a thread
- **`uploadtext.py`** — Wired the new `link_url` / `bluesky_link_url` parameters through to the Bluesky upload flow
- **`uploadposts.py`** — Minor routing adjustments to pass link URL parameters downstream

**NPM SDK (upload-post-npm)**
- **`index.js`** — Added `linkUrl` and `blueskyLinkUrl` support to `uploadText()`: sends `link_url` and `bluesky_link_url` form fields to the API. Updated `_addLinkedinParams` to send `linkedin_link_url` when in text mode
- **`index.d.ts`** — Added `LinkPreviewOptions` interface (`linkUrl`, `linkedinLinkUrl`, `blueskyLinkUrl`) and merged it into `UploadTextOptions` for full TypeScript support

### How it works

1. User passes `linkUrl` (or platform-specific `linkedinLinkUrl` / `blueskyLinkUrl`) when calling `uploadText()`
2. For **LinkedIn**: the URL is sent as `linkedin_link_url`, which LinkedIn's API uses to generate its native link preview
3. For **Bluesky**: the backend fetches OG metadata from the URL server-side, downloads and resizes the thumbnail, uploads it as a blob, and attaches a proper `AppBskyEmbedExternal` embed to the post — since Bluesky requires the client to build the card explicitly
4. A generic `linkUrl` param works across LinkedIn, Bluesky, and Facebook, while platform-specific params take priority when provided