### PR TITLE
Fix analytics dashboard metrics & API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -522,7 +522,62 @@ declare module 'upload-post' {
      * @param profileUsername - Profile username
      * @param options - Query options
      */
-    getAnalytics(profileUsername: string, options?: { platforms?: string[] }): Promise<AnalyticsResponse>;
+    getAnalytics(profileUsername: string, options?: { platforms?: string[]; pageId?: string; pageUrn?: string }): Promise<AnalyticsResponse>;
+
+    /**
+     * Get total impressions for a profile from daily snapshots
+     * @param profileUsername - Profile username
+     * @param options - Query options
+     */
+    getTotalImpressions(profileUsername: string, options?: {
+      period?: 'last_day' | 'last_week' | 'last_month' | 'last_3months' | 'last_year';
+      startDate?: string;
+      endDate?: string;
+      date?: string;
+      platforms?: string[];
+      breakdown?: boolean;
+      metrics?: string[];
+    }): Promise<{
+      success: boolean;
+      profile_username: string;
+      start_date: string;
+      end_date: string;
+      total_impressions?: number;
+      metrics?: Record<string, number>;
+      per_platform?: Record<string, number | Record<string, number>>;
+      per_day?: Record<string, number | Record<string, number>>;
+      platforms_filter?: string[];
+    }>;
+
+    /**
+     * Get analytics for a specific post across all platforms
+     * @param requestId - The request_id from the upload
+     */
+    getPostAnalytics(requestId: string): Promise<{
+      success: boolean;
+      post: { request_id: string; profile_username: string; post_title: string; post_caption: string; media_type: string; upload_timestamp: string };
+      platforms: Record<string, {
+        success: boolean;
+        platform_post_id?: string;
+        post_url?: string;
+        post_metrics?: Record<string, number>;
+        post_metrics_source?: string;
+        post_metrics_error?: string;
+        profile_snapshot_at_post_date?: Record<string, number>;
+        profile_snapshot_latest?: Record<string, number>;
+        profile_snapshot_latest_date?: string;
+        error_message?: string;
+      }>;
+    }>;
+
+    /**
+     * Get available metrics configuration for all supported platforms
+     */
+    getPlatformMetrics(): Promise<Record<string, {
+      primary_impressions_field: string;
+      available_metrics: string[];
+      metric_labels: Record<string, string>;
+    }>>;
 
     // Scheduled Posts
     /**

--- a/index.js
+++ b/index.js
@@ -614,18 +614,71 @@ export class UploadPost {
 
   /**
    * Get analytics for a profile
-   * 
+   *
    * @param {string} profileUsername - Profile username
    * @param {Object} [options] - Query options
-   * @param {string[]} [options.platforms] - Filter by platforms (instagram, linkedin, facebook, x)
-   * @returns {Promise<Object>} Analytics data
+   * @param {string[]} [options.platforms] - Filter by platforms (instagram, linkedin, facebook, x, youtube, tiktok, threads, pinterest, reddit)
+   * @param {string} [options.pageId] - Facebook Page ID (required for Facebook analytics)
+   * @param {string} [options.pageUrn] - LinkedIn page URN (defaults to "me" for personal profile)
+   * @returns {Promise<Object>} Analytics data per platform
    */
   async getAnalytics(profileUsername, options = {}) {
     const params = {};
     if (options.platforms && options.platforms.length > 0) {
       params.platforms = options.platforms.join(',');
     }
+    if (options.pageId) params.page_id = options.pageId;
+    if (options.pageUrn) params.page_urn = options.pageUrn;
     return this._request(`/analytics/${encodeURIComponent(profileUsername)}`, 'GET', params);
+  }
+
+  /**
+   * Get total impressions for a profile from daily snapshots
+   *
+   * @param {string} profileUsername - Profile username
+   * @param {Object} [options] - Query options
+   * @param {string} [options.period] - Period shortcut: last_day, last_week, last_month, last_3months, last_year
+   * @param {string} [options.startDate] - Start date in YYYY-MM-DD format
+   * @param {string} [options.endDate] - End date in YYYY-MM-DD format
+   * @param {string} [options.date] - Single date in YYYY-MM-DD format
+   * @param {string[]} [options.platforms] - Filter by platforms
+   * @param {boolean} [options.breakdown] - Include per-platform and per-day breakdown
+   * @param {string[]} [options.metrics] - Specific metrics to aggregate (e.g., ['likes', 'comments', 'shares'])
+   * @returns {Promise<Object>} Total impressions data
+   */
+  async getTotalImpressions(profileUsername, options = {}) {
+    const params = {};
+    if (options.period) params.period = options.period;
+    if (options.startDate) params.start_date = options.startDate;
+    if (options.endDate) params.end_date = options.endDate;
+    if (options.date) params.date = options.date;
+    if (options.platforms && options.platforms.length > 0) {
+      params.platform = options.platforms.join(',');
+    }
+    if (options.breakdown) params.breakdown = 'true';
+    if (options.metrics && options.metrics.length > 0) {
+      params.metrics = options.metrics.join(',');
+    }
+    return this._request(`/uploadposts/total-impressions/${encodeURIComponent(profileUsername)}`, 'GET', params);
+  }
+
+  /**
+   * Get analytics for a specific post across all platforms it was published to
+   *
+   * @param {string} requestId - The request_id from the upload
+   * @returns {Promise<Object>} Post analytics with per-platform metrics
+   */
+  async getPostAnalytics(requestId) {
+    return this._request(`/uploadposts/post-analytics/${encodeURIComponent(requestId)}`, 'GET');
+  }
+
+  /**
+   * Get available metrics configuration for all supported platforms
+   *
+   * @returns {Promise<Object>} Platform metrics config (primary fields, available metrics, labels)
+   */
+  async getPlatformMetrics() {
+    return this._request('/uploadposts/platform-metrics', 'GET');
   }
 
   // ==================== Scheduled Posts ====================


### PR DESCRIPTION
## Fix analytics dashboard: improve error handling for platform metric fetching

### Summary

Replaces silent `None` returns in `_fetch_individual_post_metrics` with descriptive error dictionaries across all platform integrations (YouTube, TikTok, Instagram, Facebook). This fixes several issues where the analytics dashboard would show blank/missing data with no indication of what went wrong.

### Changes

- **Structured error responses**: All failure paths now return `{'error': '...'}` instead of `None`, giving the frontend actionable messages (e.g., "YouTube access token missing or expired", "TikTok account not connected")
- **YouTube gap fix**: Added missing return for the case where the YouTube API returns 200 but the video ID isn't found in the response items — previously fell through silently
- **TikTok/Instagram gap fix**: Same pattern — added explicit error returns when API succeeds but the video/media isn't in the response data
- **API error logging**: Added `log()` calls before every non-200 API response for YouTube, TikTok, Instagram, and Facebook, capturing status code and truncated response body
- **Instagram insights hardening**: Replaced bare `except: pass` with logged exception handling for the insights sub-request; added status code logging for non-200 insight responses
- **Facebook empty-account check**: Added early return with error message when `facebook_accounts` is empty, instead of silently iterating over nothing
- **New platform stubs**: Added explicit "not yet supported" error returns for LinkedIn and X platforms
- **Debug tracing**: Added pre-request log lines for YouTube, TikTok, and Instagram API calls to aid debugging in production