### PR TITLE
Add tracking to distinguish n8n vs direct API

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ export class UploadPost {
       method,
       url: `${this.baseUrl}${endpoint}`,
       headers: {
-        'Authorization': `Apikey ${this.apiKey}`
+        'Authorization': `Apikey ${this.apiKey}`,
+        'X-Upload-Post-Source': 'npm',
       },
       maxContentLength: Infinity,
       maxBodyLength: Infinity


### PR DESCRIPTION
## Add `X-Upload-Post-Source` header to identify npm client requests

Adds the `X-Upload-Post-Source: npm` header to all outgoing API requests from the npm client. This allows the backend to distinguish requests originating from the npm package versus other integration sources (n8n, pip, dashboard, direct API calls).

## Changes

- **`index.js`**: Added `'X-Upload-Post-Source': 'npm'` to the default headers in the base request configuration, alongside the existing `Authorization` header.

## Context

This is part of a cross-repository effort to implement request source tracking across all Upload Post clients. The backend (`sass-ai`) now detects the origin of each request via the `X-Upload-Post-Source` header and persists it in upload stats. Each client library is responsible for self-identifying — this PR covers the npm package.