### PR TITLE
Add platform limit per queue slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ These options work across all upload methods:
 | `scheduledDate` | ISO date for scheduling |
 | `timezone` | Timezone for scheduled date |
 | `addToQueue` | Add to posting queue |
+| `maxPostsPerSlot` | Max posts per queue slot (overrides profile setting) |
 | `asyncUpload` | Process asynchronously (default: true) |
 
 ## TypeScript Support

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ declare module 'upload-post' {
     timezone?: string;
     /** Add to posting queue instead of immediate post */
     addToQueue?: boolean;
+    /** Maximum number of posts allowed per queue slot (overrides profile setting). Only used when addToQueue is true. */
+    maxPostsPerSlot?: number;
     /** Process upload asynchronously (default: true) */
     asyncUpload?: boolean;
 
@@ -380,6 +382,8 @@ declare module 'upload-post' {
     timezone?: string;
     /** Add to posting queue */
     addToQueue?: boolean;
+    /** Maximum number of posts allowed per queue slot (overrides profile setting). Only used when addToQueue is true. */
+    maxPostsPerSlot?: number;
     /** Process upload asynchronously */
     asyncUpload?: boolean;
   }

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ export class UploadPost {
     if (options.scheduledDate) form.append('scheduled_date', options.scheduledDate);
     if (options.timezone) form.append('timezone', options.timezone);
     if (options.addToQueue !== undefined) form.append('add_to_queue', String(options.addToQueue));
+    if (options.maxPostsPerSlot !== undefined) form.append('max_posts_per_slot', String(options.maxPostsPerSlot));
     if (options.asyncUpload !== undefined) form.append('async_upload', String(options.asyncUpload));
 
     // Platform-specific title overrides
@@ -578,6 +579,7 @@ export class UploadPost {
     if (options.scheduledDate) form.append('scheduled_date', options.scheduledDate);
     if (options.timezone) form.append('timezone', options.timezone);
     if (options.addToQueue !== undefined) form.append('add_to_queue', String(options.addToQueue));
+    if (options.maxPostsPerSlot !== undefined) form.append('max_posts_per_slot', String(options.maxPostsPerSlot));
     if (options.asyncUpload !== undefined) form.append('async_upload', String(options.asyncUpload));
 
     this._addLinkedinParams(form, options);


### PR DESCRIPTION
Here's the PR description:

---

## Summary

Add support for limiting the number of posts per queue time slot. Previously, each queue slot could only hold a single post — once taken, the next post would skip to the following slot. This change introduces a configurable `maxPostsPerSlot` option that allows multiple posts to share the same queue slot, giving users more flexible control over posting density.

## Changes

- **`index.js`**: Pass the new `max_posts_per_slot` form parameter to the API in both `_addCommonParams` (used by video, photo, and text uploads) and `uploadDocument`
- **`index.d.ts`**: Add `maxPostsPerSlot?: number` to `CommonUploadOptions` and `UploadDocumentOptions` TypeScript interfaces with JSDoc describing its behavior
- **`README.md`**: Document `maxPostsPerSlot` in the common options reference table

## How it works

When `addToQueue: true` is set, users can now optionally pass `maxPostsPerSlot` to override the profile-level setting for how many posts are allowed in a single queue time slot. This is a per-request override — the profile default is configured server-side via the queue settings API.

---