### PR TITLE
Fix binary data .toLowerCase() crash in n8n node

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ export class UploadPost {
     const form = new FormData();
 
     // Handle video (file path or URL)
-    if (videoPathOrUrl.toLowerCase().startsWith('http://') || videoPathOrUrl.toLowerCase().startsWith('https://')) {
+    if (typeof videoPathOrUrl === 'string' && (videoPathOrUrl.toLowerCase().startsWith('http://') || videoPathOrUrl.toLowerCase().startsWith('https://'))) {
       form.append('video', videoPathOrUrl);
     } else {
       if (!fs.existsSync(videoPathOrUrl)) {
@@ -562,7 +562,7 @@ export class UploadPost {
     const form = new FormData();
 
     // Handle document (file path or URL)
-    if (documentPathOrUrl.toLowerCase().startsWith('http://') || documentPathOrUrl.toLowerCase().startsWith('https://')) {
+    if (typeof documentPathOrUrl === 'string' && (documentPathOrUrl.toLowerCase().startsWith('http://') || documentPathOrUrl.toLowerCase().startsWith('https://'))) {
       form.append('document', documentPathOrUrl);
     } else {
       if (!fs.existsSync(documentPathOrUrl)) {


### PR DESCRIPTION
## Fix: Prevent `.toLowerCase()` crash when binary data is passed to upload functions

When the n8n Upload Post node receives binary data (e.g., a `Buffer`) instead of a string URL for video or document inputs, calling `.toLowerCase()` on non-string values throws a `TypeError`, crashing the node execution.

This PR adds `typeof` guards before `.toLowerCase()` calls to ensure the value is a string before attempting string operations. If the value is not a string (i.e., binary data), it correctly falls through to the file-handling branch.

## Changes

- **`index.js:367`** — Added `typeof videoPathOrUrl === 'string'` check before URL detection in `uploadVideo`, preventing crash when binary data is passed as the video input.
- **`index.js:565`** — Added `typeof documentPathOrUrl === 'string'` check before URL detection in `uploadDocument`, applying the same fix for document uploads.

## Root Cause

The URL-detection conditionals assumed inputs would always be strings, but n8n can pass binary `Buffer` objects when users connect binary data from upstream nodes. Calling `.toLowerCase()` on a `Buffer` throws:

```
TypeError: videoPathOrUrl.toLowerCase is not a function
```

## Testing

- Binary data inputs now fall through to the file-handling path instead of crashing.
- String URL inputs (`http://` / `https://`) continue to be detected and handled as URLs.
- File path strings continue to work unchanged.