### PR TITLE
Add Reddit link post support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -315,6 +315,8 @@ declare module 'upload-post' {
     redditSubreddit?: string;
     /** Flair template ID */
     redditFlairId?: string;
+    /** URL for a Reddit link post (kind=link) instead of a self post */
+    redditLinkUrl?: string;
   }
 
   // ==================== Combined Upload Options ====================

--- a/index.js
+++ b/index.js
@@ -272,6 +272,7 @@ export class UploadPost {
   _addRedditParams(form, options) {
     if (options.redditSubreddit) form.append('subreddit', options.redditSubreddit);
     if (options.redditFlairId) form.append('flair_id', options.redditFlairId);
+    if (options.redditLinkUrl) form.append('reddit_link_url', options.redditLinkUrl);
   }
 
   /**


### PR DESCRIPTION
## PR Description for `upload-post-npm`

---

## Add Reddit link posts (kind=link) support

Extends the npm SDK to support Reddit link posts in addition to the existing self (text) posts. When a `redditLinkUrl` is provided, the Reddit API submission uses `kind=link` with the URL instead of `kind=self` with text body.

### Changes

- **`index.d.ts`**: Added `redditLinkUrl?: string` property to the `RedditOptions` interface, with JSDoc describing its purpose — creating a link post (`kind=link`) instead of a self post
- **`index.js`**: Updated `_addRedditParams()` to append `reddit_link_url` to the form data when `options.redditLinkUrl` is provided

### Usage

```js
const client = new UploadPost('your-api-key');

// Self post (existing behavior, unchanged)
await client.uploadText({
  title: 'My post title',
  user: 'profile1',
  platforms: ['reddit'],
  redditSubreddit: 'javascript',
});

// Link post (new)
await client.uploadText({
  title: 'Check out this article',
  user: 'profile1',
  platforms: ['reddit'],
  redditSubreddit: 'javascript',
  redditLinkUrl: 'https://example.com/article',
});
```

### Context

This mirrors the existing link post pattern already supported for other platforms (e.g., `blueskyLinkUrl`, `facebookLinkUrl`, `linkedinLinkUrl`). The backend changes in `sass-ai` handle the `reddit_link_url` form field and switch between `kind=self` and `kind=link` when calling the Reddit API.