### PR TITLE
Add first_comment support for LinkedIn posts

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ export class UploadPost {
     if (options.youtubeFirstComment) form.append('youtube_first_comment', options.youtubeFirstComment);
     if (options.redditFirstComment) form.append('reddit_first_comment', options.redditFirstComment);
     if (options.blueskyFirstComment) form.append('bluesky_first_comment', options.blueskyFirstComment);
+    if (options.linkedinFirstComment) form.append('linkedin_first_comment', options.linkedinFirstComment);
 
     if (options.firstCommentMedia) {
       const mediaItems = Array.isArray(options.firstCommentMedia) ? options.firstCommentMedia : [options.firstCommentMedia];


### PR DESCRIPTION
## Add First Comment Support for LinkedIn Posts

Adds the ability to post a "first comment" on LinkedIn posts immediately after publishing, matching existing functionality available on other platforms like X/Twitter.

### Changes

- **`social_utils.py`** — Added `post_linkedin_first_comment()` utility function that posts a comment to the LinkedIn REST API (`/rest/comments`) using the post URN and actor URN, with proper error handling and logging.

- **`uploadposts.py`** — Wired `first_comment` parameter through to LinkedIn upload calls for video, photo, document, and text post flows. Added form field extraction (`first_comment` / `linkedin_first_comment`) in the document upload endpoint.

- **`uploadphotos.py`** — Added `first_comment` parameter to `upload_photo_linkedin()` and calls `post_linkedin_first_comment()` after successful post creation.

- **`uploaddocuments.py`** — Added `first_comment` parameter to `upload_document_linkedin()` and calls `post_linkedin_first_comment()` after successful post creation.

- **`uploadtext.py`** — Added `first_comment` parameter to the LinkedIn text upload flow.

- **`uploadvideos.py`** — Added `first_comment` parameter to the LinkedIn video upload flow.

### Implementation Details

- The first comment is only posted when both `first_comment` content and a valid `post_id` exist
- Uses LinkedIn API v202510 with `X-Restli-Protocol-Version: 2.0.0`
- Failures in first comment posting are logged but do not fail the overall post upload — this is intentional to avoid losing a successfully published post due to a comment error
- Consistent pattern across all LinkedIn post types (text, photo, video, document)