### PR TITLE
Add get_job_status method to Python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ const status = await client.getStatus('request_id_from_upload');
 console.log(status);
 ```
 
+For scheduled or queued posts, check the status using the job_id:
+
+```javascript
+const status = await client.getJobStatus('job_id_from_scheduled_post');
+console.log(status);
+```
+
 ### Get Upload History
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -516,6 +516,12 @@ declare module 'upload-post' {
     getStatus(requestId: string): Promise<StatusResponse>;
 
     /**
+     * Get the status of a scheduled or queued upload by job ID
+     * @param jobId - The job_id from a scheduled or queued upload
+     */
+    getJobStatus(jobId: string): Promise<StatusResponse>;
+
+    /**
      * Get upload history
      * @param options - Query options
      */

--- a/index.js
+++ b/index.js
@@ -621,6 +621,16 @@ export class UploadPost {
   }
 
   /**
+   * Get the status of a scheduled or queued upload by job ID
+   *
+   * @param {string} jobId - The job_id from a scheduled or queued upload
+   * @returns {Promise<Object>} Upload status
+   */
+  async getJobStatus(jobId) {
+    return this._request('/uploadposts/status', 'GET', { job_id: jobId });
+  }
+
+  /**
    * Get upload history
    * 
    * @param {Object} [options] - Query options


### PR DESCRIPTION
## Add `getJobStatus` method to query upload status by job ID

The `/api/uploadposts/status` endpoint accepts both `request_id` and `job_id` parameters, but the JS client only exposed `getStatus(requestId)`. This adds a corresponding `getJobStatus(jobId)` method for checking the status of scheduled or queued posts.

### Changes

- **`index.js`** — Added `getJobStatus(jobId)` method that calls `/uploadposts/status` with `{ job_id: jobId }`
- **`index.d.ts`** — Added TypeScript declaration for `getJobStatus`, returning `Promise<StatusResponse>`
- **`README.md`** — Added usage example showing how to check status using a job ID