### PR TITLE
Add Google Business Profile selection in OAuth

### DIFF
--- a/index.js
+++ b/index.js
@@ -845,6 +845,30 @@ export class UploadPost {
     const params = profile ? { profile } : {};
     return this._request('/uploadposts/pinterest/boards', 'GET', params);
   }
+
+  /**
+   * Get Google Business Profile locations for a connected account
+   *
+   * @param {string} [profile] - Profile username
+   * @returns {Promise<Object>} List of Google Business locations
+   */
+  async getGoogleBusinessLocations(profile) {
+    const params = profile ? { profile } : {};
+    return this._request('/uploadposts/google-business/locations', 'GET', params);
+  }
+
+  /**
+   * Select a specific Google Business Profile location for a profile
+   *
+   * @param {string} locationId - The location ID to select (e.g. "accounts/123/locations/456")
+   * @param {string} [profile] - Profile username
+   * @returns {Promise<Object>} Selection result with google_business_id and display_name
+   */
+  async selectGoogleBusinessLocation(locationId, profile) {
+    const data = { location_id: locationId };
+    if (profile) data.profile = profile;
+    return this._request('/uploadposts/google-business/locations/select', 'POST', data);
+  }
 }
 
 // Default export for CommonJS compatibility


### PR DESCRIPTION
Based on my analysis of the full codebase and the provided diff, here's the PR description:

---

## [FEATURE] Allow user selection of Google Business Profile during OAuth

### Summary

Adds the ability for users to select a specific Google Business Profile location when multiple locations are available under a single account. Previously, the system automatically selected the first location, which was problematic for businesses managing multiple locations.

### Changes

**Backend (`sass-ai`)**

- **`callbacks.py`** — Updated the Google Business OAuth callback to accept an optional `location_id` parameter. When provided, the callback matches the requested location instead of defaulting to the first one. Added `needs_location_selection` flag to the response when multiple locations exist and none was explicitly selected.
- **`platformspecifics.py`** — Added two new endpoints:
  - `GET /api/uploadposts/google-business/locations` — Retrieves all available locations for a connected Google Business account, including which one is currently selected.
  - `POST /api/uploadposts/google-business/locations/select` — Allows switching the active location for a profile after initial OAuth setup.
- **`upload_google_business.py`** — Minor adjustments to support the new location selection flow.
- **`analytics.py`** — Added Google Business support in analytics.

**NPM SDK (`upload-post-npm`)**

- **`index.js`** — Added two new client methods:
  - `getGoogleBusinessLocations(profile)` — Fetches available locations for a connected account.
  - `selectGoogleBusinessLocation(locationId, profile)` — Selects a specific location by ID.

### How it works

1. During OAuth, if the account has multiple locations, the response includes `needs_location_selection: true` along with all available locations.
2. The frontend can then present a location picker to the user.
3. The selected location is confirmed via the new `/locations/select` endpoint.
4. Users can also switch locations post-setup using the same endpoint.