### PR TITLE
Add Threads topic tag support to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ const boards = await client.getPinterestBoards('my-profile');
 ### Threads
 - `threadsLongTextAsPost` - Post long text as single post (vs thread)
 - `threadsThreadMediaLayout` - Comma-separated list of how many media items to include in each Threads post. Each value must be 1-10, and the total must equal the number of files. Example: '5,5' splits 10 items into 2 posts with 5 each. If omitted and more than 10 items are provided, auto-chunks into groups of 10.
+- `threadsTopicTag` - Topic tag for the Threads post (1-50 characters, no periods or ampersands). One tag per post. Helps increase reach.
 
 ### Reddit
 - `redditSubreddit` - Subreddit name (without r/)

--- a/index.js
+++ b/index.js
@@ -280,6 +280,7 @@ export class UploadPost {
   _addThreadsParams(form, options) {
     if (options.threadsLongTextAsPost !== undefined) form.append('threads_long_text_as_post', String(options.threadsLongTextAsPost));
     if (options.threadsThreadMediaLayout) form.append('threads_thread_media_layout', options.threadsThreadMediaLayout);
+    if (options.threadsTopicTag) form.append('threads_topic_tag', options.threadsTopicTag);
   }
 
   /**
@@ -377,6 +378,7 @@ export class UploadPost {
    * Threads options:
    * @param {boolean} [options.threadsLongTextAsPost] - Post long text as single post (vs thread)
    * @param {string} [options.threadsThreadMediaLayout] - Comma-separated list of how many media items per Threads post (e.g. "5,5")
+   * @param {string} [options.threadsTopicTag] - Topic tag for the Threads post (1-50 chars, no periods or ampersands)
    *
    * @returns {Promise<Object>} API response with request_id for async uploads
    */
@@ -458,6 +460,7 @@ export class UploadPost {
    * Threads options:
    * @param {boolean} [options.threadsLongTextAsPost] - Post long text as single post
    * @param {string} [options.threadsThreadMediaLayout] - Comma-separated list of how many media items per Threads post (e.g. "5,5")
+   * @param {string} [options.threadsTopicTag] - Topic tag for the Threads post (1-50 chars, no periods or ampersands)
    *
    * Reddit options:
    * @param {string} [options.redditSubreddit] - Subreddit name (without r/)
@@ -533,6 +536,7 @@ export class UploadPost {
    * Threads options:
    * @param {boolean} [options.threadsLongTextAsPost] - Post long text as single post
    * @param {string} [options.threadsThreadMediaLayout] - Comma-separated list of how many media items per Threads post (e.g. "5,5")
+   * @param {string} [options.threadsTopicTag] - Topic tag for the Threads post (1-50 chars, no periods or ampersands)
    *
    * Reddit options:
    * @param {string} [options.redditSubreddit] - Subreddit name (without r/)


### PR DESCRIPTION
## Add Threads Topic Tag Support to API

Adds support for the Threads `topic_tag` parameter across all upload flows (text, photo, and video), allowing users to categorize their Threads posts by topic.

### Changes

- **Input validation** (`uploadposts.py`): Added `threads_topic_tag` form parameter extraction with validation in both `upload_to_platforms` and `upload_photos_to_platforms` entry points — rejects tags over 50 characters or containing periods (`.`) or ampersands (`&`), per Threads API constraints.

- **Photo uploads** (`uploadphotos.py`): 
  - `upload_photo_threads` now accepts `threads_topic_tag` parameter
  - Passes `topic_tag` to single-item container creation params
  - Passes `topic_tag` through the `_create_and_publish_carousel` helper for carousel/multi-image posts
  - Only the first/main post in a thread receives the topic tag (replies do not)

- **Video uploads** (`uploadposts.py`): Passes `threads_topic_tag` from the request form through to `upload_threads` in `_execute_video_upload`.

- **Text uploads** (`uploadtext.py`): Added `threads_topic_tag` support (based on diff pattern, 8 lines changed).

- **Cleanup**: Removed unused imports (`refresh_job_summary`, `utcnow`) from `durable_uploads`.

### API Usage

Add the optional `threads_topic_tag` field to upload requests:

```
threads_topic_tag=Technology
```

Validation rules:
- Max 50 characters
- Cannot contain `.` or `&`