### PR TITLE
feat(sdk): add getPostAnalyticsByPlatformId method

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,8 +721,8 @@ export class UploadPost {
   async getPostAnalyticsByPlatformId(platformPostId, platform, user) {
     return this._request('/uploadposts/post-analytics', 'GET', {
       platform_post_id: platformPostId,
-      platform: platform,
-      user: user,
+      platform,
+      user,
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -711,6 +711,22 @@ export class UploadPost {
   }
 
   /**
+   * Get analytics for any post (including organic posts) using its native platform ID
+   *
+   * @param {string} platformPostId - The native post ID on the platform (e.g., Instagram media ID)
+   * @param {string} platform - The platform to query (instagram, youtube, tiktok, facebook, linkedin, x, threads, pinterest, reddit)
+   * @param {string} user - The profile_username that owns the social account
+   * @returns {Promise<Object>} Post analytics with live per-post metrics from the platform API
+   */
+  async getPostAnalyticsByPlatformId(platformPostId, platform, user) {
+    return this._request('/uploadposts/post-analytics', 'GET', {
+      platform_post_id: platformPostId,
+      platform: platform,
+      user: user,
+    });
+  }
+
+  /**
    * Get available metrics configuration for all supported platforms
    *
    * @returns {Promise<Object>} Platform metrics config (primary fields, available metrics, labels)


### PR DESCRIPTION
## Summary
- Add `getPostAnalyticsByPlatformId(platformPostId, platform, user)` method to Node.js SDK
- Enables querying post analytics by native platform ID for organic posts

## Changes
- `index.js`: Added new method with JSDoc documentation

## Testing
- Verify method sends correct query params to `/uploadposts/post-analytics`
- Test with valid Instagram media ID, platform, and profile username

Co-Authored-By: Claude (noreply@anthropic.com)