### PR TITLE
feat(instagram): support binary cover image for Reels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,8 +136,8 @@ declare module 'upload-post' {
     instagramShareToFeed?: boolean;
     /** Comma-separated collaborator usernames */
     instagramCollaborators?: string;
-    /** Custom cover URL */
-    instagramCoverUrl?: string;
+    /** Custom cover URL, file path, or Buffer. URLs are sent directly; file paths and Buffers are uploaded as binary. */
+    instagramCoverUrl?: string | Buffer | NodeJS.ReadableStream;
     /** Audio track name */
     instagramAudioName?: string;
     /** Comma-separated user tags */

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ declare module 'upload-post' {
     instagramShareToFeed?: boolean;
     /** Comma-separated collaborator usernames */
     instagramCollaborators?: string;
-    /** Custom cover URL, file path, or Buffer. URLs are sent directly; file paths and Buffers are uploaded as binary. */
+    /** Custom cover: URL string, file path, Buffer, or ReadableStream */
     instagramCoverUrl?: string | Buffer | NodeJS.ReadableStream;
     /** Audio track name */
     instagramAudioName?: string;

--- a/index.js
+++ b/index.js
@@ -160,7 +160,18 @@ export class UploadPost {
 
     if (isVideo) {
       if (options.instagramShareToFeed !== undefined) form.append('share_to_feed', String(options.instagramShareToFeed));
-      if (options.instagramCoverUrl) form.append('cover_url', options.instagramCoverUrl);
+      if (options.instagramCoverUrl) {
+        const coverVal = options.instagramCoverUrl;
+        if (typeof coverVal === 'string' && (coverVal.toLowerCase().startsWith('http://') || coverVal.toLowerCase().startsWith('https://'))) {
+          form.append('cover_url', coverVal);
+        } else if (typeof coverVal === 'string') {
+          // File path — send as binary upload
+          form.append('cover_image', createReadStream(coverVal));
+        } else {
+          // Buffer or stream — send as binary upload
+          form.append('cover_image', coverVal);
+        }
+      }
       if (options.instagramAudioName) form.append('audio_name', options.instagramAudioName);
       if (options.instagramThumbOffset) form.append('thumb_offset', options.instagramThumbOffset);
     }
@@ -326,7 +337,7 @@ export class UploadPost {
    * @param {string} [options.instagramMediaType] - REELS or STORIES
    * @param {boolean} [options.instagramShareToFeed] - Share to feed
    * @param {string} [options.instagramCollaborators] - Comma-separated collaborator usernames
-   * @param {string} [options.instagramCoverUrl] - Custom cover URL
+   * @param {string|Buffer|ReadableStream} [options.instagramCoverUrl] - Custom cover URL, file path, or binary data. URLs are sent directly; file paths and Buffers are uploaded as binary.
    * @param {string} [options.instagramAudioName] - Audio track name
    * @param {string} [options.instagramUserTags] - Comma-separated user tags
    * @param {string} [options.instagramLocationId] - Location ID

--- a/index.js
+++ b/index.js
@@ -165,10 +165,8 @@ export class UploadPost {
         if (typeof coverVal === 'string' && (coverVal.toLowerCase().startsWith('http://') || coverVal.toLowerCase().startsWith('https://'))) {
           form.append('cover_url', coverVal);
         } else if (typeof coverVal === 'string') {
-          // File path — send as binary upload
           form.append('cover_image', createReadStream(coverVal));
         } else {
-          // Buffer or stream — send as binary upload
           form.append('cover_image', coverVal);
         }
       }
@@ -337,7 +335,7 @@ export class UploadPost {
    * @param {string} [options.instagramMediaType] - REELS or STORIES
    * @param {boolean} [options.instagramShareToFeed] - Share to feed
    * @param {string} [options.instagramCollaborators] - Comma-separated collaborator usernames
-   * @param {string|Buffer|ReadableStream} [options.instagramCoverUrl] - Custom cover URL, file path, or binary data. URLs are sent directly; file paths and Buffers are uploaded as binary.
+   * @param {string|Buffer|ReadableStream} [options.instagramCoverUrl] - Custom cover: URL string, file path, Buffer, or ReadableStream
    * @param {string} [options.instagramAudioName] - Audio track name
    * @param {string} [options.instagramUserTags] - Comma-separated user tags
    * @param {string} [options.instagramLocationId] - Location ID


### PR DESCRIPTION
## Summary
- Update `instagramCoverUrl` to accept file paths and Buffers in addition to URLs
- Non-URL values are sent as binary `cover_image` in multipart form data

## Changes
- Update `_addInstagramParams()` to detect URL vs file path/Buffer for cover images
- Update TypeScript types: `instagramCoverUrl` now accepts `string | Buffer | NodeJS.ReadableStream`
- Update JSDoc to document the new input types

## Testing
- Pass a URL string — should send as `cover_url` (existing behavior)
- Pass a file path — should send as `cover_image` via `createReadStream()`
- Pass a Buffer — should send as `cover_image` binary

Co-Authored-By: Claude (noreply@anthropic.com)