### PR TITLE
feat(youtube): add subtitle upload support to SDK

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,17 @@ declare module 'upload-post' {
     youtubeHasPaidProductPlacement?: boolean;
     /** Recording date (ISO 8601) */
     youtubeRecordingDate?: string;
+    /** Subtitle/caption files to upload. Each entry needs a language code and either a file path or URL. */
+    youtubeSubtitles?: Array<{
+      /** BCP-47 language code (e.g. "en", "es") */
+      language: string;
+      /** Display name for the subtitle track (e.g. "English", "Español") */
+      name?: string;
+      /** Path to the subtitle file (SRT, VTT, SBV, SUB, ASS, SSA, TTML) */
+      file?: string;
+      /** URL to the subtitle file */
+      url?: string;
+    }>;
   }
 
   // ==================== LinkedIn Options ====================

--- a/index.js
+++ b/index.js
@@ -198,6 +198,24 @@ export class UploadPost {
     if (options.youtubeBlockedCountries) form.append('blockedCountries', options.youtubeBlockedCountries);
     if (options.youtubeHasPaidProductPlacement !== undefined) form.append('hasPaidProductPlacement', String(options.youtubeHasPaidProductPlacement));
     if (options.youtubeRecordingDate) form.append('recordingDate', options.youtubeRecordingDate);
+    if (options.youtubeSubtitles && Array.isArray(options.youtubeSubtitles)) {
+      options.youtubeSubtitles.forEach((sub, idx) => {
+        if (sub.language) {
+          form.append(`youtube_subtitle_language_${idx}`, sub.language);
+          if (sub.name) form.append(`youtube_subtitle_name_${idx}`, sub.name);
+          if (sub.file) {
+            // file can be a string path or a ReadableStream
+            if (typeof sub.file === 'string') {
+              form.append(`youtube_subtitle_file_${idx}`, createReadStream(sub.file));
+            } else {
+              form.append(`youtube_subtitle_file_${idx}`, sub.file);
+            }
+          } else if (sub.url) {
+            form.append(`youtube_subtitle_file_${idx}`, sub.url);
+          }
+        }
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `youtubeSubtitles` option for uploading subtitle/caption files to YouTube videos
- Support multiple subtitle tracks with language codes, display names, and file paths or URLs

## Changes
- `index.js`: Add subtitle handling in `_addYoutubeParams()` to append indexed subtitle form fields
- `index.d.ts`: Add `youtubeSubtitles` type definition to `YouTubeOptions` interface

## Testing
- Upload a video with `youtubeSubtitles` array containing subtitle tracks
- Verify subtitle files are sent as multipart form data with correct field names
- Test with file paths and URLs

Co-Authored-By: Claude (noreply@anthropic.com)