### PR TITLE
feat(media): add getMedia() with LinkedIn page_urn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,22 @@ const analytics = await client.getAnalytics('my-profile', {
 console.log(analytics);
 ```
 
+### Get Media
+
+Retrieve recent posts from a connected social account. Supported platforms:
+`instagram`, `tiktok`, `youtube`, `linkedin`, `facebook`, `x`, `threads`,
+`pinterest`, `bluesky`, `reddit`.
+
+```javascript
+const { media } = await client.getMedia('linkedin', 'my-profile');
+
+// Force the personal LinkedIn profile of an account connected as an org admin:
+await client.getMedia('linkedin', 'my-profile', { pageUrn: 'me' });
+
+// Target a specific LinkedIn organization page:
+await client.getMedia('linkedin', 'my-profile', { pageUrn: '12345' });
+```
+
 ### Helper Methods
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -592,16 +592,7 @@ declare module 'upload-post' {
     /**
      * Get recent media from a connected social account.
      *
-     * Supports: instagram, tiktok, youtube, linkedin, facebook, x, threads,
-     * pinterest, bluesky, reddit.
-     *
-     * @param platform - Platform key
-     * @param user - Profile username
-     * @param options - LinkedIn-only options
-     * @param options.pageUrn - Numeric org ID, full org URN, or "me" to force the
-     *   personal profile. When omitted, accounts linked as an organization admin
-     *   auto-resolve to the first administered organization; otherwise the
-     *   personal profile is used.
+     * @param options.pageUrn - LinkedIn only. Numeric org ID, full org URN, or "me" to force the personal profile.
      */
     getMedia(
       platform: 'instagram' | 'tiktok' | 'youtube' | 'linkedin' | 'facebook' | 'x' | 'threads' | 'pinterest' | 'bluesky' | 'reddit' | string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -589,6 +589,37 @@ declare module 'upload-post' {
       metric_labels: Record<string, string>;
     }>>;
 
+    /**
+     * Get recent media from a connected social account.
+     *
+     * Supports: instagram, tiktok, youtube, linkedin, facebook, x, threads,
+     * pinterest, bluesky, reddit.
+     *
+     * @param platform - Platform key
+     * @param user - Profile username
+     * @param options - LinkedIn-only options
+     * @param options.pageUrn - Numeric org ID, full org URN, or "me" to force the
+     *   personal profile. When omitted, accounts linked as an organization admin
+     *   auto-resolve to the first administered organization; otherwise the
+     *   personal profile is used.
+     */
+    getMedia(
+      platform: 'instagram' | 'tiktok' | 'youtube' | 'linkedin' | 'facebook' | 'x' | 'threads' | 'pinterest' | 'bluesky' | 'reddit' | string,
+      user: string,
+      options?: { pageUrn?: string }
+    ): Promise<{
+      success: boolean;
+      media: Array<{
+        id: string;
+        caption: string | null;
+        media_type: 'IMAGE' | 'VIDEO' | 'CAROUSEL_ALBUM' | 'TEXT' | string;
+        media_url: string | null;
+        permalink: string | null;
+        timestamp: string | null;
+        thumbnail_url: string | null;
+      }>;
+    }>;
+
     // Scheduled Posts
     /**
      * List scheduled posts

--- a/index.js
+++ b/index.js
@@ -744,6 +744,26 @@ export class UploadPost {
     return this._request('/uploadposts/platform-metrics', 'GET');
   }
 
+  /**
+   * Get recent media (posts, reels, videos, pins, tweets) from a connected
+   * social account. Supports instagram, tiktok, youtube, linkedin, facebook,
+   * x, threads, pinterest, bluesky, reddit.
+   *
+   * @param {string} platform - Platform key
+   * @param {string} user - Profile username (as configured in Upload-Post)
+   * @param {Object} [options]
+   * @param {string} [options.pageUrn] - LinkedIn only. Numeric org ID (e.g. "12345"),
+   *   full URN ("urn:li:organization:12345"), or "me" to force the personal profile.
+   *   When omitted, accounts linked as an org admin auto-resolve to the first
+   *   administered organization; otherwise the personal profile is used.
+   * @returns {Promise<Object>} { success, media: Array<{ id, caption, media_type, media_url, permalink, timestamp, thumbnail_url }> }
+   */
+  async getMedia(platform, user, options = {}) {
+    const params = { platform, user };
+    if (options.pageUrn) params.page_urn = options.pageUrn;
+    return this._request('/uploadposts/media', 'GET', params);
+  }
+
   // ==================== Scheduled Posts ====================
 
   /**

--- a/index.js
+++ b/index.js
@@ -745,18 +745,13 @@ export class UploadPost {
   }
 
   /**
-   * Get recent media (posts, reels, videos, pins, tweets) from a connected
-   * social account. Supports instagram, tiktok, youtube, linkedin, facebook,
-   * x, threads, pinterest, bluesky, reddit.
+   * Get recent media from a connected social account.
    *
-   * @param {string} platform - Platform key
-   * @param {string} user - Profile username (as configured in Upload-Post)
+   * @param {string} platform - instagram, tiktok, youtube, linkedin, facebook, x, threads, pinterest, bluesky, reddit
+   * @param {string} user - Profile username
    * @param {Object} [options]
-   * @param {string} [options.pageUrn] - LinkedIn only. Numeric org ID (e.g. "12345"),
-   *   full URN ("urn:li:organization:12345"), or "me" to force the personal profile.
-   *   When omitted, accounts linked as an org admin auto-resolve to the first
-   *   administered organization; otherwise the personal profile is used.
-   * @returns {Promise<Object>} { success, media: Array<{ id, caption, media_type, media_url, permalink, timestamp, thumbnail_url }> }
+   * @param {string} [options.pageUrn] - LinkedIn only. Numeric org ID, full URN, or "me" to force the personal profile.
+   * @returns {Promise<Object>}
    */
   async getMedia(platform, user, options = {}) {
     const params = { platform, user };


### PR DESCRIPTION
## Summary
Surface the `/uploadposts/media` endpoint as a first-class SDK method so customers don't have to hand-roll the request. The `pageUrn` option maps to the backend's new LinkedIn auto-resolve / `me` override behavior.

## Changes
- `index.js`: add `getMedia(platform, user, { pageUrn })`.
- `index.d.ts`: typed signature with the platform enum and response shape.
- `README.md`: usage example for personal + organization LinkedIn fetches.

## Testing
- [ ] \`new UploadPost(apiKey).getMedia('linkedin', 'my-profile')\` → returns the auto-resolved default.
- [ ] \`getMedia('linkedin', 'my-profile', { pageUrn: 'me' })\` and \`{ pageUrn: '12345' }\` both forward the param correctly (verify via network log).
- [ ] TypeScript consumers compile against the new declarations.

Co-Authored-By: Claude (noreply@anthropic.com)